### PR TITLE
kernel_definitions: Find all possible dtbs

### DIFF
--- a/kernel_definitions.mk
+++ b/kernel_definitions.mk
@@ -340,8 +340,4 @@ $(RTIC_DTB): $(INSTALLED_KERNEL_TARGET)
 
 # Creating a dtb.img once the kernel is compiled if TARGET_KERNEL_APPEND_DTB is set to be false
 $(INSTALLED_DTBIMAGE_TARGET): $(INSTALLED_KERNEL_TARGET) $(RTIC_DTB)
-ifneq (,$(wildcard $(TARGET_KERNEL_SOURCE)/arch/arm64/boot/dts/vendor))
-	cat $(KERNEL_OUT)/arch/$(KERNEL_ARCH)/boot/dts/vendor/$(TARGET_DTS_VENDOR)/*.dtb $(RTIC_DTB) > $@
-else
-	cat $(KERNEL_OUT)/arch/$(KERNEL_ARCH)/boot/dts/$(TARGET_DTS_VENDOR)/*.dtb $(RTIC_DTB) > $@
-endif
+	cat $(shell find $(KERNEL_OUT)/arch/$(KERNEL_ARCH)/boot/dts -type f -name "*.dtb" | sort) > $@


### PR DESCRIPTION
Don't hardcode dtb path.

ls kernel/msm-4.19/arch/arm64/boot/dts/vendor
19805  19811  19821  19855  20801  20809  20813  20828  bindings  Makefile  qcom

Signed-off-by: Yuan Si <do4suki@gmail.com>
Change-Id: I1fa7270c4d32f2dfa4dc0e4ee3fc3e4b02645a6c